### PR TITLE
App: Improve "ls" response and modularity

### DIFF
--- a/Private/ls/ls.js
+++ b/Private/ls/ls.js
@@ -1,0 +1,76 @@
+#!/usr/bin/env node
+
+const path = require('path');
+const fs = require('file-system');
+
+/**
+ *
+ * Responds to an 'ls' request ("/ls/*"), given the request & response
+ *
+ * @param{http.ClientRequest} req The URL requested
+ * @param{http.ServerResponse} res The response object to write to
+ *
+ */
+function ls(req, res) {
+  // turn request URL into useful Path
+  let lsURL = req.url.split(path.sep);
+  lsURL = lsURL.slice(2, lsURL.length);
+
+  let lsPath = path.join('Public/', lsURL.join('/'));
+
+  console.log(`Files list request for ${lsPath}`);
+
+  // get stats on valid directory and respond appropriately
+  fs.stat(lsPath, (err, stats) => {
+    // error handling
+    if (err) {
+      res.status(500)
+          .jsonp({error: err})
+          .end();
+    }
+
+    // if no error but PATH is to file, get parent directory
+    if (stats.isFile()) {
+      let filename = lsURL[lsURL.length - 1];
+      lsPath = lsPath.slice(0, lsPath.length - filename.length);
+    }
+
+    console.log(`Retrieving files at ${lsPath}`);
+
+    // get list of files in requested directory
+    let filesObj = {
+      url: lsPath.slice(6, lsPath.length),
+      directories: ['.', '..'],
+      files: [],
+    };
+
+    fs.readdir(lsPath, (err, dir) => {
+      // error handling
+      if (err) {
+        res.status(500)
+            .jsonp({error: err})
+            .end();
+      }
+
+      // processing files
+      dir.forEach((file) => {
+        let relative = path.join(lsPath, file);
+        if (fs.lstatSync(relative).isDirectory()) {
+          filesObj.directories.push(file);
+        } else {
+          filesObj.files.push(file);
+        }
+      });
+
+      // send out found information
+      console.log(filesObj);
+      res.status(200)
+          .jsonp(filesObj)
+          .end();
+
+      console.log();
+    });
+  });
+}
+
+module.exports = ls;

--- a/Private/ls/package-lock.json
+++ b/Private/ls/package-lock.json
@@ -1,0 +1,57 @@
+{
+  "name": "ls",
+  "version": "1.0.0",
+  "lockfileVersion": 1,
+  "requires": true,
+  "dependencies": {
+    "file-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/file-match/-/file-match-1.0.2.tgz",
+      "integrity": "sha1-ycrSZdLIrfOoFHWw30dYWQafrvc=",
+      "requires": {
+        "utils-extend": "^1.0.6"
+      }
+    },
+    "file-system": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/file-system/-/file-system-2.2.2.tgz",
+      "integrity": "sha1-fWWDPjojR9zZVqgTxncVPtPt2Yc=",
+      "requires": {
+        "file-match": "^1.0.1",
+        "utils-extend": "^1.0.4"
+      }
+    },
+    "inherits": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+      "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
+    },
+    "path": {
+      "version": "0.12.7",
+      "resolved": "https://registry.npmjs.org/path/-/path-0.12.7.tgz",
+      "integrity": "sha1-1NwqUGxM4hl+tIHr/NWzbAFAsQ8=",
+      "requires": {
+        "process": "^0.11.1",
+        "util": "^0.10.3"
+      }
+    },
+    "process": {
+      "version": "0.11.10",
+      "resolved": "https://registry.npmjs.org/process/-/process-0.11.10.tgz",
+      "integrity": "sha1-czIwDoQBYb2j5podHZGn1LwW8YI="
+    },
+    "util": {
+      "version": "0.10.4",
+      "resolved": "https://registry.npmjs.org/util/-/util-0.10.4.tgz",
+      "integrity": "sha512-0Pm9hTQ3se5ll1XihRic3FDIku70C+iHUdT/W926rSgHV5QgXsYbKZN8MSC3tJtSkhuROzvsQjAaFENRXr+19A==",
+      "requires": {
+        "inherits": "2.0.3"
+      }
+    },
+    "utils-extend": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/utils-extend/-/utils-extend-1.0.8.tgz",
+      "integrity": "sha1-zP17ZFQPjpDuIe7Fd2nQZRyril8="
+    }
+  }
+}

--- a/Private/ls/package.json
+++ b/Private/ls/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "ls",
+  "version": "1.0.0",
+  "description": "A function to handle 'ls' requests of my site",
+  "main": "ls.js",
+  "scripts": {
+    "test": "node-dev ls"
+  },
+  "keywords": [
+    "ls",
+    "file-system"
+  ],
+  "author": "Evan Keeton",
+  "license": "ISC",
+  "dependencies": {
+    "file-system": "^2.2.2",
+    "path": "^0.12.7"
+  }
+}

--- a/index.js
+++ b/index.js
@@ -1,8 +1,10 @@
 #!/usr/bin/env node
 
+// node modules
 const express = require('express');
-const path = require('path');
-const fs = require('file-system');
+
+// my modules
+const ls = require('ls');
 
 // Define PORT & create app
 const PORT = process.env.PORT || 8888; // set PORT to 8888 if not env variable
@@ -10,72 +12,7 @@ const app = express();
 
 // Define an "ls" method to list files in a directory
 app.get('/ls/*', (req, res) => {
-  // turn request URL into useful Path
-  let lsURL;
-  lsURL = req.url.split(path.sep);
-  lsURL = lsURL.slice(2, lsURL.length);
-
-  let lsPath = path.join('Public/', lsURL.join('/'));
-
-  console.log(`Files list request for ${lsPath}`);
-
-  // get stats on valid directory and respond appropriately
-  fs.stat(lsPath, (err, stats) => {
-    // error handling
-    if (err) {
-      res.status(500)
-          .jsonp({error: err})
-          .end();
-
-      return 1;
-    }
-
-    // if no error but PATH is to file, get parent directory
-    if (stats.isFile()) {
-      filename = lsURL[lsURL.length - 1]
-      lsPath = lsPath.slice(0, lsPath.length - filename.length)
-    }
-
-    console.log(`Retrieving files at ${lsPath}`);
-
-    // get list of files in requested directory
-    let filesObj = {
-      url: lsPath.slice(6, lsPath.length),
-      directories: ['.', '..'],
-      files: [],
-    };
-
-    fs.readdir(lsPath, (err, dir) => {
-      // error handling
-      if (err) {
-        res.status(500)
-            .jsonp({error: err})
-            .end();
-
-        return 1;
-      }
-
-      // processing files
-      dir.forEach((file) => {
-        let relative = path.join(lsPath, file);
-        if (fs.lstatSync(relative).isDirectory()) {
-          filesObj.directories.push(file);
-        } else {
-          filesObj.files.push(file);
-        }
-      });
-
-      // send out found information
-      console.log(filesObj);
-      res.status(200)
-          .jsonp(filesObj)
-          .end();
-
-      console.log();
-
-      return 0;
-    });
-  });
+  ls(req, res);
 });
 
 // Create the Static Path to Public, and make / redirect to /Public

--- a/index.js
+++ b/index.js
@@ -15,47 +15,66 @@ app.get('/ls/*', (req, res) => {
   lsURL = req.url.split(path.sep);
   lsURL = lsURL.slice(2, lsURL.length);
 
-  let lsPath = './Public/';
-  lsURL.forEach((partial) => {
-    if (partial !== '') lsPath += partial + '/';
-  });
+  let lsPath = path.join('Public/', lsURL.join('/'));
 
   console.log(`Files list request for ${lsPath}`);
 
-  // get list of files in requested directory
-  let filesObj = {
-    url: lsPath.slice(8, lsPath.length),
-    directories: ['.', '..'],
-    files: [],
-  };
-
-  fs.readdir(lsPath, (err, dir) => {
+  // get stats on valid directory and respond appropriately
+  fs.stat(lsPath, (err, stats) => {
     // error handling
     if (err) {
-      res.status(500).jsonp({error: err});
-      res.end();
+      res.status(500)
+          .jsonp({error: err})
+          .end();
+
       return 1;
     }
 
-    // processing files
-    dir.forEach((file) => {
-      let relative = path.join(lsPath, file);
-      if (fs.lstatSync(relative).isDirectory()) {
-        filesObj.directories.push(file);
-      } else {
-        filesObj.files.push(file);
+    // if no error but PATH is to file, get parent directory
+    if (stats.isFile()) {
+      filename = lsURL[lsURL.length - 1]
+      lsPath = lsPath.slice(0, lsPath.length - filename.length)
+    }
+
+    console.log(`Retrieving files at ${lsPath}`);
+
+    // get list of files in requested directory
+    let filesObj = {
+      url: lsPath.slice(6, lsPath.length),
+      directories: ['.', '..'],
+      files: [],
+    };
+
+    fs.readdir(lsPath, (err, dir) => {
+      // error handling
+      if (err) {
+        res.status(500)
+            .jsonp({error: err})
+            .end();
+
+        return 1;
       }
+
+      // processing files
+      dir.forEach((file) => {
+        let relative = path.join(lsPath, file);
+        if (fs.lstatSync(relative).isDirectory()) {
+          filesObj.directories.push(file);
+        } else {
+          filesObj.files.push(file);
+        }
+      });
+
+      // send out found information
+      console.log(filesObj);
+      res.status(200)
+          .jsonp(filesObj)
+          .end();
+
+      console.log();
+
+      return 0;
     });
-
-    // send out found information
-    console.log(filesObj);
-    res.status(200)
-        .jsonp(filesObj)
-        .end();
-
-    console.log();
-
-    return 0;
   });
 });
 

--- a/index.js
+++ b/index.js
@@ -53,6 +53,8 @@ app.get('/ls/*', (req, res) => {
         .jsonp(filesObj)
         .end();
 
+    console.log();
+
     return 0;
   });
 });

--- a/package-lock.json
+++ b/package-lock.json
@@ -143,23 +143,6 @@
         "vary": "~1.1.2"
       }
     },
-    "file-match": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/file-match/-/file-match-1.0.2.tgz",
-      "integrity": "sha1-ycrSZdLIrfOoFHWw30dYWQafrvc=",
-      "requires": {
-        "utils-extend": "^1.0.6"
-      }
-    },
-    "file-system": {
-      "version": "2.2.2",
-      "resolved": "https://registry.npmjs.org/file-system/-/file-system-2.2.2.tgz",
-      "integrity": "sha1-fWWDPjojR9zZVqgTxncVPtPt2Yc=",
-      "requires": {
-        "file-match": "^1.0.1",
-        "utils-extend": "^1.0.4"
-      }
-    },
     "finalhandler": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.1.2.tgz",
@@ -213,6 +196,64 @@
       "version": "1.9.0",
       "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.0.tgz",
       "integrity": "sha512-M4Sjn6N/+O6/IXSJseKqHoFc+5FdGJ22sXqnjTpdZweHK64MzEPAyQZyEU3R/KRv2GLoa7nNtg/C2Ev6m7z+eA=="
+    },
+    "ls": {
+      "version": "file:Private/ls",
+      "requires": {
+        "file-system": "^2.2.2",
+        "path": "^0.12.7"
+      },
+      "dependencies": {
+        "file-match": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/file-match/-/file-match-1.0.2.tgz",
+          "integrity": "sha1-ycrSZdLIrfOoFHWw30dYWQafrvc=",
+          "requires": {
+            "utils-extend": "^1.0.6"
+          }
+        },
+        "file-system": {
+          "version": "2.2.2",
+          "resolved": "https://registry.npmjs.org/file-system/-/file-system-2.2.2.tgz",
+          "integrity": "sha1-fWWDPjojR9zZVqgTxncVPtPt2Yc=",
+          "requires": {
+            "file-match": "^1.0.1",
+            "utils-extend": "^1.0.4"
+          }
+        },
+        "inherits": {
+          "version": "2.0.3",
+          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+          "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
+        },
+        "path": {
+          "version": "0.12.7",
+          "resolved": "https://registry.npmjs.org/path/-/path-0.12.7.tgz",
+          "integrity": "sha1-1NwqUGxM4hl+tIHr/NWzbAFAsQ8=",
+          "requires": {
+            "process": "^0.11.1",
+            "util": "^0.10.3"
+          }
+        },
+        "process": {
+          "version": "0.11.10",
+          "resolved": "https://registry.npmjs.org/process/-/process-0.11.10.tgz",
+          "integrity": "sha1-czIwDoQBYb2j5podHZGn1LwW8YI="
+        },
+        "util": {
+          "version": "0.10.4",
+          "resolved": "https://registry.npmjs.org/util/-/util-0.10.4.tgz",
+          "integrity": "sha512-0Pm9hTQ3se5ll1XihRic3FDIku70C+iHUdT/W926rSgHV5QgXsYbKZN8MSC3tJtSkhuROzvsQjAaFENRXr+19A==",
+          "requires": {
+            "inherits": "2.0.3"
+          }
+        },
+        "utils-extend": {
+          "version": "1.0.8",
+          "resolved": "https://registry.npmjs.org/utils-extend/-/utils-extend-1.0.8.tgz",
+          "integrity": "sha1-zP17ZFQPjpDuIe7Fd2nQZRyril8="
+        }
+      }
     },
     "media-typer": {
       "version": "0.3.0",
@@ -270,24 +311,10 @@
       "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
       "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ=="
     },
-    "path": {
-      "version": "0.12.7",
-      "resolved": "https://registry.npmjs.org/path/-/path-0.12.7.tgz",
-      "integrity": "sha1-1NwqUGxM4hl+tIHr/NWzbAFAsQ8=",
-      "requires": {
-        "process": "^0.11.1",
-        "util": "^0.10.3"
-      }
-    },
     "path-to-regexp": {
       "version": "0.1.7",
       "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.7.tgz",
       "integrity": "sha1-32BBeABfUi8V60SQ5yR6G/qmf4w="
-    },
-    "process": {
-      "version": "0.11.10",
-      "resolved": "https://registry.npmjs.org/process/-/process-0.11.10.tgz",
-      "integrity": "sha1-czIwDoQBYb2j5podHZGn1LwW8YI="
     },
     "proxy-addr": {
       "version": "2.0.5",
@@ -395,19 +422,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
       "integrity": "sha1-sr9O6FFKrmFltIF4KdIbLvSZBOw="
-    },
-    "util": {
-      "version": "0.10.4",
-      "resolved": "https://registry.npmjs.org/util/-/util-0.10.4.tgz",
-      "integrity": "sha512-0Pm9hTQ3se5ll1XihRic3FDIku70C+iHUdT/W926rSgHV5QgXsYbKZN8MSC3tJtSkhuROzvsQjAaFENRXr+19A==",
-      "requires": {
-        "inherits": "2.0.3"
-      }
-    },
-    "utils-extend": {
-      "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/utils-extend/-/utils-extend-1.0.8.tgz",
-      "integrity": "sha1-zP17ZFQPjpDuIe7Fd2nQZRyril8="
     },
     "utils-merge": {
       "version": "1.0.1",

--- a/package.json
+++ b/package.json
@@ -26,7 +26,6 @@
   "dependencies": {
     "eslint-config-google": "^0.13.0",
     "express": "^4.17.1",
-    "file-system": "^2.2.2",
-    "path": "^0.12.7"
+    "ls": "file:Private/ls"
   }
 }


### PR DESCRIPTION
# Improve `ls` Response

- beautify output (add a newline between calls)
- check that requested path exists
   - if the path does exist as a directory, respond with what is found in that directory
   - if the path does exist as a *file*, respond with the contents of the parent directory
   - if the path does *not* exist, respond with an error

# Improve Modularity

- create a `/Private/` folder for holding modular code
- create a local module `ls`, which exports the function `ls`
   - this function replaces the code inside the `get` response to `/ls/*`
- require the local module `ls` as a dependency