### PR TITLE
Ensure Links have '/' (Fix #7)

### DIFF
--- a/Private/ls/ls.js
+++ b/Private/ls/ls.js
@@ -44,7 +44,7 @@ function ls(req, res) {
 
     // get list of files in requested directory
     let filesObj = {
-      url: lsPath.slice(6, lsPath.length),
+      url: path.join(lsPath.slice(6, lsPath.length), '/'),
       directories: ['.', '..'],
       files: [],
     };

--- a/Public/assets/scripts/file_explorer.js
+++ b/Public/assets/scripts/file_explorer.js
@@ -56,9 +56,10 @@ function setProperties(lsRes, title, url, dirs, files) {
   url.appendChild(URLlink);
 
   lsRes.directories.forEach((dir) => {
+    dirname = dir + '/';
     let dirLink = document.createElement('a');
-    dirLink.href = new URL(lsRes.url + dir, window.location.origin);
-    dirLink.innerText = dir + '/';
+    dirLink.href = new URL(lsRes.url + dirname, window.location.origin);
+    dirLink.innerText = dirname;
     dirs.appendChild(dirLink);
     dirs.appendChild(document.createElement('br'));
   });


### PR DESCRIPTION
- Ensure that 'ls' always ends the url in filesObj with a `/`
- Ensure that file_explorer.js always ends urls for child directories
  with a `/`